### PR TITLE
Don't rely on knowing what . is in a bash script

### DIFF
--- a/GeodesyMLToSiteLog/generate-bindings-for-geodesymltositelog.sh
+++ b/GeodesyMLToSiteLog/generate-bindings-for-geodesymltositelog.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 set -e
-PYTHON_PREFIX=.
+PYTHON_PREFIX=${BASH_SOURCE%/*}/..
 PYXBGEN=${PYTHON_PREFIX}/pyxbgen
 
-${PYXBGEN} -u ../GeodesyML/schemas/geodesyML.xsd \
+${PYXBGEN} -u "${PYTHON_PREFIX}/GeodesyML/schemas/geodesyML.xsd" \
 	-m geodesymltositelog_bindings \
 	--archive-path "${PYTHON_PREFIX}"/pyxb/bundles/common/raw/:"${PYTHON_PREFIX}"/pyxb/bundles/opengis/raw/:.:+

--- a/SiteLogToGeodesyML/generate-bindings-for-sitelogtogeodesyml.sh
+++ b/SiteLogToGeodesyML/generate-bindings-for-sitelogtogeodesyml.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 set -e
-PYTHON_PREFIX=.
+PYTHON_PREFIX=${BASH_SOURCE%/*}/..
 PYXBGEN=${PYTHON_PREFIX}/pyxbgen
 
-${PYXBGEN} -u ../modified-schemas/geodesyML.xsd \
+${PYXBGEN} -u "${PYTHON_PREFIX}/modified-schemas/geodesyML.xsd" \
     -m sitelogtogeodesyml_bindings \
 	--archive-path "${PYTHON_PREFIX}"/pyxb/bundles/common/raw/:"${PYTHON_PREFIX}"/pyxb/bundles/opengis/raw/:.:+


### PR DESCRIPTION
Prefer to operate relative to the directory that contains the script,
rather than the directory from which the script is invoked.