### PR TITLE
Changed README instructions for terraform init

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ terraform init \
 	-backend-config "bucket=auscors-terraform-state-dev" \
 	-backend-config "lock_table=auscors-terraform-state-dev" \
 	-backend-config "region=ap-southeast-2" \
-	-backend-config "key=auscors-sitelogs/dev"
+	-backend-config "key=auscors-sitelogs/dev/terraform.tfstate"
 
 terraform get
 terraform plan


### PR DESCRIPTION
Changed README instructions for terraform init - new version of terraform (v0.10.0) views key variable as full key name, instead of just a prefix, so there including the standard filename of terraform.tfstate is nicer.