### PR TITLE
Remove nillable double types from monumentInfo.xsd

### DIFF
--- a/SiteLogToGeodesyML/modified-schemas/monumentInfo.xsd
+++ b/SiteLogToGeodesyML/modified-schemas/monumentInfo.xsd
@@ -199,9 +199,9 @@ Copyright: Scripps Orbit and Permanent Array Center (SOPAC), Commonwealth Govern
             <element name="cdpNumber" type="string"/>
             <!-- TODO: use gco -->
             <element minOccurs="0" name="monumentDescription" type="gml:CodeType"/>
-            <element minOccurs="0" name="heightOfTheMonument" type="geo:NillableDouble"/>
+            <element minOccurs="0" name="heightOfTheMonument" type="double"/>
             <element minOccurs="0" name="monumentFoundation" type="string"/>
-            <element minOccurs="0" name="foundationDepth" type="geo:NillableDouble"/>
+            <element minOccurs="0" name="foundationDepth" type="double"/>
             <element minOccurs="0" name="markerDescription" type="string"/>
             <element minOccurs="0" name="dateInstalled" type="gml:TimePositionType"/>
             <!-- TODO: use gco -->


### PR DESCRIPTION
Elements `heightOfTheMonument` and `foundationDepth` are optional.