### PR TITLE
Fix secondary telephone mapping

### DIFF
--- a/SiteLogToGeodesyML/sitelogtogeodesyml.py
+++ b/SiteLogToGeodesyML/sitelogtogeodesyml.py
@@ -1913,7 +1913,7 @@ class ContactAgency(object):
             voice.append(self.telephone[1])
 
             voice2 = gco.CharacterString_PropertyType()
-            voice2.append(self.telephone2[0])
+            voice2.append(self.telephone2[1])
 
             telephone = pyxb.BIND(voice, voice2)
             phoneProperty.append(telephone)

--- a/tests/sitelog_to_geodesyml/expected_output/t000_20170101.xml
+++ b/tests/sitelog_to_geodesyml/expected_output/t000_20170101.xml
@@ -108,7 +108,7 @@
                                     <gco:CharacterString></gco:CharacterString>
                                 </gmd:voice>
                                 <gmd:voice>
-                                    <gco:CharacterString>456</gco:CharacterString>
+                                    <gco:CharacterString></gco:CharacterString>
                                 </gmd:voice>
                                 <gmd:facsimile>
                                     <gco:CharacterString></gco:CharacterString>


### PR DESCRIPTION
Secondary telephone number of primary contact was being mapped to
secondary telephone number of the secondary contact.