### PR TITLE
Stop running --upgrade on pip install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 install:
   - pip -v install -r requirements-dev.txt
   - pip -v install -r requirements.txt
-  - pip -v install . --upgrade
+  - pip -v install .
 
 script:
   - pytest


### PR DESCRIPTION
Passing upgrade to pip install causes pip to overwrite the pinned
version of pyxb specified requirements.txt.