### PR TITLE
Freeze pytest-console-scripts

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 pytest
-pytest-console-scripts
+pytest-console-scripts==0.2.0


### PR DESCRIPTION
Version 1.0.0 doesn't work for us anymore.